### PR TITLE
[PR]: Establish Foundational Backend Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,376 @@
 HELP.md
-target/
-.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
 
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
+# (!) General & Secrets (Important)
+## Ignore local environment variables & secrets
+.env
+.env.*.local
+application-local.properties
+application-dev.properties
 
-### IntelliJ IDEA ###
-.idea
+# H2 database files
+*.mv.db
+*.trace.db
+
+# Spring Boot DevTools trigger file
+.spring-boot-devtools.properties
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos,git,maven,visualstudiocode,intellij,java,netbeans,eclipse,database
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos,git,maven,visualstudiocode,intellij,java,netbeans,eclipse,database
+
+### Database ###
+*.accdb
+*.db
+*.dbf
+*.mdb
+*.pdb
+*.sqlite3
+*.db-shm
+*.db-wal
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
 *.iws
-*.iml
-*.ipr
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
 
 ### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
 build/
-!**/src/main/**/build/
-!**/src/test/**/build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
 
-### VS Code ###
+### VisualStudioCode ###
 .vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos,git,maven,visualstudiocode,intellij,java,netbeans,eclipse,database

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2025 Gabriel ML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# herbarium-backend
+# 🚧 Herbarium
+
+## 🤔 Overview
+
+Herbarium will be a full-stack web application that allows users to explore a comprehensive database of medicinal plants, save their favorites in a personal dashboard, and create and manage their own herbal recipes and preparation methods.
+
+## ✨ Features & Requirements
+
+The objective of this final project will be to meet the following key requirements, which will serve as guiding principles for its development.
+
+1. **User Authentication & Authorization:** Secure login/logout and user registration.
+2. **Plant Exploration:** Search, filter, and browse plants from the [Pernual API](https://perenual.com/).
+3. **Favorites Management:** Users can add/remove plants from their personal favorites list.
+4. **Personal Herbarium (Dashboard):** A private area for users to view their favorites and manage their custom recipes.
+5. **Recipe Management:** Create, Read, Update, and Delete (CRUD) personal herbal recipes associated with specific plants.
+
+## ℹ️ About
+
+This project is part of the [Full Stack Web Development training program](https://factoriaf5.org/aprende/desarrollo-web-full-stack-asturias/) in [Asturias](https://en.wikipedia.org/wiki/Asturias), offered by [Factoría F5](https://factoriaf5.org/).
+
+The curriculum covers a wide range of topics, from basic programming languages ​​and UX principles to advanced project development techniques. It includes front-end and back-end technologies, agile methodologies, and tools for user experience design and database development. The program also focuses on essential soft skills such as communication, problem-solving, teamwork, adaptability, and time management.
+
+## 📧 Contact
+
+For any questions or inquiries, please do not hesitate to contact me!
+
+Happy coding! 🌱 🐒

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>dev.gml</groupId>
 	<artifactId>herbarium-backend</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>herbarium-backend</name>
 	<description>A collection of preserved plant specimens &amp; associated data used for personal study</description>
-	<url/>
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>21</java.version>
@@ -122,6 +123,47 @@
 						</exclude>
 					</excludes>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>INSTRUCTION</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.00</minimum> <!-- TODO: For this Captstone
+											Project, JaCoCo should be 0.70 (70% test coverage) but
+											if not reach BUILD WILL FAIL! -->
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 			<artifactId>mysql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,41 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.6.3</version>
+				<configuration>
+					<source>${java.version}</source>
+					<doctitle>Herbarium Backend API Documentation (v${project.version})</doctitle>
+					<windowtitle>Herbarium Backend API Documentation</windowtitle>
+					<show>public</show>
+					<failOnError>false</failOnError>
+
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>package</phase>
+					</execution>
+					<execution>
+						<id>site</id>
+						<phase>site</phase>
+						<goals>
+							<goal>javadoc</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/dev/gml/herbarium_backend/HerbariumJacocoService.java
+++ b/src/main/java/dev/gml/herbarium_backend/HerbariumJacocoService.java
@@ -2,13 +2,41 @@ package dev.gml.herbarium_backend;
 
 import org.springframework.stereotype.Service;
 
+/**
+ * <b>For configuration &amp; testing purposes only!</b>
+ * <p>
+ * Primarily for the <a href="https://www.eclemma.org/jacoco/">JaCoCo</a>
+ * &amp; <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html">JavaDoc</a>
+ * plugins.
+ * <p>
+ * Service layer component responsible for core Herbarium business logic,
+ * primarily for status checks &amp; simple calculations.
+ * 
+ * @author gml
+ * @version 1.0
+ */
 @Service
 public class HerbariumJacocoService {
+
+    /**
+     * Retrieves the current active status message for the Herbarium backend.
+     * This is a health check utility method.
+     * 
+     * @return A string indicating the service is active.
+     */
     public String getStatus() {
         return "Herbarium-Backend is Active!";
     }
 
-    // An untested method to demonstrate coverage logic:
+    /**
+     * Performs a basic arithmetic calculation based on the sign of the first number.
+     * Used for demonstration purposes.
+     * 
+     * @param a The first integer. If positive, it is added.
+     * @param b The second integer to be added or subtracted.
+     * @return The result of (a + b) if a > 0, otherwise (a - b).
+     * @since 0.0.1-SNAPSHOT
+     */
     public int calculate(int a, int b) {
         if (a > 0) {
             return a + b;

--- a/src/main/java/dev/gml/herbarium_backend/HerbariumJacocoService.java
+++ b/src/main/java/dev/gml/herbarium_backend/HerbariumJacocoService.java
@@ -1,0 +1,19 @@
+package dev.gml.herbarium_backend;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HerbariumJacocoService {
+    public String getStatus() {
+        return "Herbarium-Backend is Active!";
+    }
+
+    // An untested method to demonstrate coverage logic:
+    public int calculate(int a, int b) {
+        if (a > 0) {
+            return a + b;
+        } else {
+            return a - b;
+        }
+    }
+}

--- a/src/main/java/dev/gml/herbarium_backend/OpenApiConfig.java
+++ b/src/main/java/dev/gml/herbarium_backend/OpenApiConfig.java
@@ -1,0 +1,64 @@
+package dev.gml.herbarium_backend;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+/**
+ * <b>OPENAPI (<a href="https://swagger.io/">Swagger</a>) Configuration for the
+ * Herbarium Backend API. </b>
+ * <p>
+ * This class defines the metadata that will appear at the top of the
+ * Swagger UI (API Documentation) page. It establishes the central
+ * contract for the REST API consumed by the frontend application.
+ */
+@Configuration
+// @Configuration: This is a Spring annotation that tells the Spring IoC
+// Container that this class contains one or more methods annotated with
+// @Bean, which should be processed to generate bean definitions
+// and service requests at runtime. Without this, Spring ignores the file.
+public class OpenApiConfig {
+
+    /**
+     * <p>
+     * Defines the custom OpenAPI object with metadata. </b>
+     * 
+     * @return The configured OpenAPI object.
+     */
+    @Bean
+    // @Bean: This method produces a bean (a reusable object) to be managed
+    // by the Spring container. The Springdoc library automatically looks
+    // for an OpenAPI bean to apply custom configuration metadata.
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                // The main OpenAPI object that holds all documentation metadata.
+                .info(new Info()
+                        // Info: Contains the application-level metadata.
+
+                        // title(): Sets the prominent title displayed at the top of the Swagger UI
+                        // page.
+                        .title("Herbarium Backend API")
+
+                        // version(): Uses the project's version defined in pom.xml
+                        .version("0.0.1-SNAPSHOT")
+
+                        // description(): Provides the detailed explanatory text below the title.
+                        .description("API documentation for the Herbarium Full-Stack Web Application backend. "
+                                + "It manages plant specimens, associated data, and user security.")
+
+                        // termsOfService(): Optional-provides a link to terms, good for professional
+                        // appearance.
+                        .termsOfService("http://swagger.io/terms/"));
+    }
+
+}
+
+// Spring IoC (Inversion of Control)
+// Spring's Inversion of Control (IoC) principle flips
+// the script. With IoC, I delegate the responsibility
+// of object creation and dependency management to the
+// Spring container. Instead of creating objects explicitly,
+// I define their dependencies through configuration files or
+// annotations.

--- a/src/main/java/dev/gml/herbarium_backend/SecurityConfig.java
+++ b/src/main/java/dev/gml/herbarium_backend/SecurityConfig.java
@@ -1,0 +1,98 @@
+package dev.gml.herbarium_backend;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * <b> Spring Security Configuration for development.</b>
+ * <p>
+ * This class customizes Spring Security's default behavior. Its primary
+ * role is to explicitly whitelist paths needed for development and
+ * documentation
+ * (<a href="https://swagger.io/">Swagger</a> UI and
+ * <a href="https://www.h2database.com/html/main.html">H2</a> Console) to
+ * prevent
+ * the application from redirecting unauthenticated request to a login form.
+ */
+@Configuration
+// @Configuration: Marks this class as a source of bean definitions.
+// Spring finds this and processes the @Bean methods inside.
+@EnableWebSecurity
+// @EnableWebSecurity: Enables Spring Security's web security support
+// and provides the Spring MVC integration. It is essential for using the
+// HttpSecurity object to configure rules.
+public class SecurityConfig {
+
+    /**
+     * <b> Array of URL patterns that must be accessible without authentication.
+     * </b>
+     * <p>
+     * Includes all paths required for API documentation and development tools.
+     */
+    private static final String[] SWAGGER_PATHS = {
+            "/swagger-ui.html", // The main Swagger UI page.
+            "/swagger-ui/**", // Resources like CSS, JS, and image files that feeds the UI.
+            "/v3/api-docs/**", // The raw OpenAPI JSON/YAML file that feeds the UI.
+            "/webjars/**", // Resources required by Swagger, often served via webjars.
+            "/h2-console/**" // Allows access to the in-memory H2 database UI (for development only).
+    };
+
+    /**
+     * <b> Defines the Security Filter Chain, which is the core of Spring Security.
+     * </b>
+     * <p>
+     * This bean specifies the custom security rules that are applied to incoming
+     * request.
+     * 
+     * @param http The HttpSecurity object used to build security configuration.
+     * @return The configured {@link SecurityFilterChain} bean.
+     * @throws Exception
+     */
+    @Bean
+    // @Bean: Makes the resulting SecurityFilterChain object available in the Spring
+    // context.
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // ----------------------------------------------------------------------------
+        // 1. CROSS-SITE REQUEST FORGERY (CSRF)
+        // ----------------------------------------------------------------------------
+        // CSRF must be disabled for the H2 console to function properly, as it
+        // doesn't send a CSRF token. It is also often disabled for stateless
+        // REST APIs using token-based security (like JWT).
+        // NOTE: This is generally unsafe for browser-based (stateful) applications
+        // and must be re-enabled or configured properly for production environments!
+        // TODO: Revisit CSRF configuration for production!
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // ----------------------------------------------------------------------------
+        // 2. AUTHORIZATION RULES
+        // ----------------------------------------------------------------------------
+        // Configure authorization rules (i.e., who can access which path).
+        http.authorizeHttpRequests(authorize -> authorize
+                // Allow unauthenticated access to all whitelisted paths (documentation/dev
+                // tools)
+                .requestMatchers(SWAGGER_PATHS).permitAll()
+
+                // Temporarily permit all other requests (my actual API endpoints)
+                // This makes development easier for now but means any API call is allowed.
+                // TODO: This is generally unsafe. Must be changed to
+                // `.anyRequest().authenticated()`
+                // for production to enforce token-based security on all endpoints.
+                .anyRequest().permitAll());
+
+        // ---------------------------------------------------------------------------
+        // 3. AUTHENTICATION MECHANISM
+        // ---------------------------------------------------------------------------
+        // Disable the default login form provided by Spring Security.
+        // If this were left enabled, any request to a protected path would be
+        // redirected to the browser-based sign-in form.
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        // Finalize the configuration and return the filter chain.
+        return http.build();
+    }
+
+}

--- a/src/main/java/dev/gml/herbarium_backend/StatusController.java
+++ b/src/main/java/dev/gml/herbarium_backend/StatusController.java
@@ -1,0 +1,66 @@
+package dev.gml.herbarium_backend;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * <b> STATUS CONTROLLER (MOCK) </b>
+ * <p>
+ * This file is for configuration &amp; testing purposes only! It demonstrates
+ * the basic
+ * structure of a Spring REST controller and allows for basic health checks.
+ * <p>
+ * The Controller layer is the entry point for all externall HTTP requests.
+ */
+@RestController
+// @RestController: This is a composite annotation combining @Controller and
+// @ResponseBody. It tells Spring:
+// 1. This class handles web requests.
+// 2. All method return values should be automatically serialized into
+// the HTTP response body (e.g., JSON or, in this case, a simple string).
+@Tag(name = "Health Check", description = "Endpoints for verifying application status and health.")
+// @Tag (from Swagger): Defines a group/category for the API documentation
+// in the Swagger UI. All operations in this controller will be listed under
+// the "Health Check" category
+public class StatusController {
+
+    // private final: The standard practice for fields that hold dependencies.
+    // It enforces immutability, ensuring the service reference cannot be changed.
+    private final HerbariumJacocoService service;
+
+    /**
+     * <b> Constructor Injection </b>
+     * <p>
+     * This is the preferred way to handle dependencies in Spring. When Spring
+     * creates an instance of this controller, it automatically finds the
+     * required 'HerbariumJacocoService' bean and passes it into this constructor.
+     */
+    public StatusController(HerbariumJacocoService service) {
+        // Assigns the injected service instance to the local final field.
+        this.service = service;
+    }
+
+    /**
+     * <b> Health Check Endpoint </b>
+     * <p>
+     * Retrieves the current application status message by delegating the
+     * request to the Service Layer (HerbariumJacocoService).
+     * 
+     * @return A simple status string ("Herbarium-Backend is Active!").
+     */
+    @GetMapping("/api/status")
+    // @GetMapping: Maps HTTP GET request to the specified URL path.
+    // When a user hits "http://localhost:8080/api/status", this method is executed.
+    @Operation(summary = "Get application health status", description = "Returns a simple status string.")
+    // @Operation (from Swagger): Provides detailed, per-method documentation
+    // for the Swagger UI, including the short summary and the longer description.
+    public String getStatus() {
+        // Delegate: The Controller's job is to route and handle HTTP concerns,
+        // while the Service's job is to handle business logic. This line
+        // follows the "Thin Controller, Thick Service" pattern.
+        return service.getStatus();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,24 @@
+# --------------------------------------------------------------------------
+# CORE APPLICATION PROPERTIES
+# --------------------------------------------------------------------------
+
+# spring.application.name:
+# It defines a name for the app. This is used in Spring Boot Actuator,
+# logging, and externalized configuration systems like Spring Cloud Config.
 spring.application.name=herbarium-backend
+
+# ---------------------------------------------------------------------------
+# DOCKER COMPOSE / TESTCONTAINERS CONFIGURATION
+# ---------------------------------------------------------------------------
+
+# spring.docker.compose.enabled:
+# Controls Spring Boot's automatic startup of Docker Compose files (e.g., compose.yaml)
+# detected in the project root. This feature is enabled by default if the
+# 'spring-boot-docker-compose' dependency is present
+
+# TEMPORARILY disable Docker Compose auto-start for local development,
+# as the Docker daemon is not guaranteed to be running.
+# Setting this to 'false' prevents the application from failing to start
+# when the Docker daemon is not active, allowing local development and testing
+# (like JaCoCo and Swagger verification) to proceed.
+spring.docker.compose.enabled=false

--- a/src/test/java/dev/gml/herbarium_backend/HerbariumBackendApplicationTests.java
+++ b/src/test/java/dev/gml/herbarium_backend/HerbariumBackendApplicationTests.java
@@ -2,9 +2,9 @@ package dev.gml.herbarium_backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+// FIXME2o3: import org.springframework.context.annotation.Import; // Active it in the future for test contatiners configuration!
 
-@Import(TestcontainersConfiguration.class)
+// FIXME1o3: @Import(TestcontainersConfiguration_DISABLED.class) // Active it in the future for test contatiners configuration!
 @SpringBootTest
 class HerbariumBackendApplicationTests {
 

--- a/src/test/java/dev/gml/herbarium_backend/HerbariumJacocoServiceTest.java
+++ b/src/test/java/dev/gml/herbarium_backend/HerbariumJacocoServiceTest.java
@@ -1,0 +1,37 @@
+package dev.gml.herbarium_backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+
+// @SpringBootTest ensure the service is available.
+@SpringBootTest
+public class HerbariumJacocoServiceTest {
+
+    @Autowired
+    private HerbariumJacocoService service;
+
+    @Test
+    @DisplayName("JaCoCo Setup Test: 1. It should return 'Herbarium-Backend is Active!'")
+    void getStatus_shouldReturnActiveMessage() {
+        // This test covers the "getStatus" method:
+        String expected = "Herbarium-Backend is Active!";
+
+        assertEquals(expected, service.getStatus());
+    }
+
+    @Test
+    @DisplayName("JaCoCo Setup Test: 2. It should only cover the first branch of the 'if/else' statement")
+    void calculate_shouldCoverFirstBranch() {
+        // This covers the 'if(a > 0)' branch:
+        assertEquals(5, service.calculate(3, 2));
+    }
+
+    // Note: The 'else' branch of calculate is left uncoverd for now.
+    // JaCoCo will flag this partial coverage.
+
+}

--- a/src/test/java/dev/gml/herbarium_backend/TestHerbariumBackendApplication.java
+++ b/src/test/java/dev/gml/herbarium_backend/TestHerbariumBackendApplication.java
@@ -5,7 +5,12 @@ import org.springframework.boot.SpringApplication;
 public class TestHerbariumBackendApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.from(HerbariumBackendApplication::main).with(TestcontainersConfiguration.class).run(args);
+		// The .with(TestcontainersConfiguration_DISABLED.class) also explicitly
+		// loads the Testcontainers setup. It should be commented in the initial setup.
+		// FIXME 3o3:
+		// SpringApplication.from(HerbariumBackendApplication::main).with(TestcontainersConfiguration_DISABLED.class).run(args);
+		// Active it in the future for test contatiners configuration and comment the next line!
+		SpringApplication.from(HerbariumBackendApplication::main).run(args);
 	}
 
 }

--- a/src/test/java/dev/gml/herbarium_backend/TestcontainersConfiguration_DISABLED.java
+++ b/src/test/java/dev/gml/herbarium_backend/TestcontainersConfiguration_DISABLED.java
@@ -7,7 +7,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration {
+class TestcontainersConfiguration_DISABLED {
 
 	@Bean
 	@ServiceConnection


### PR DESCRIPTION
# 🚀 Feature: Initial Backend Foundation Setup

This branch introduces all core configurations, quality tooling, and documentation necessary to begin feature development on the `herbarium-backend` service.

All changes are focused on **Developer Experience (DX)**, **Quality Assurance**, and **API Contract Definition**.

---

## What was implemented:

### 1. 📝 Updated README file
The update of this document briefly explains the purpose of this final project, making it clear **what** is intended to be built and **why**.

### 2. 📚 Documentation and API Contract
* **API Documentation ([Swagger UI](https://swagger.io/)):** Integrated `springdoc-openapi-starter-webmvc-ui` to automatically generate interactive REST API documentation.
    * Defined API metadata (Title, Version, Description) in `OpenApiConfig.java`.
    * Created a temporary `StatusController.java` to verify the setup.
* **[JavaDoc](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html):** `maven-javadoc-plugin` is configured to generate documentation for public APIs.

### 3. ✅ Quality and Testing Baseline
* **Code Coverage ([JaCoCo](https://www.eclemma.org/jacoco/)):** Integrated the `jacoco-maven-plugin` and configured rules to track code coverage (currently set to 0.00% to allow initial commits, but ready to enforce stricter metrics later).
     [#2]
* **Testing Infrastructure:** Added a baseline test case (`HerbariumJacocoServiceTest.java`) to verify the Spring context loads and JaCoCo is active.

### 4. 🔒 Security and Development Environment Fixes
* **Development Tools Exposure:** Created `SecurityConfig.java` to whitelist necessary development paths:
    * `swagger-ui/**`, `/v3/api-docs/**`
    * `/h2-console/**`
    * CSRF is disabled, and `.anyRequest().permitAll()` is set **temporarily** for development flexibility.
* **Startup Fix:** Disabled Docker Compose auto-start in `application.properties` to ensure the application starts locally without the Docker daemon running.

---

## 🛑 Follow-up Issues Created

The following tasks were logged as issues for future implementation, as they are not part of the initial structure:
1.  **[#4 ]** Implement production-ready JWT authentication to replace `.permitAll()`.
2.  **[#3 ]** Remove temporary configuration files (`StatusController.java`, etc.) once a real domain model is implemented.

**Reviewer Note:** Please review the individual commits for detailed explanations of the changes and fixes (e.g., the Docker and Security blocks).

---

## ⚡Commands for Generation
1. **[JaCoCo](https://www.eclemma.org/jacoco/)**
    - To generate the JaCoCo report: `$ mvn clean verify`
    - Look in the `target` folder for the report files. You should see:
        - `target/surefire-reports` (The test results)
        - `target/jacoco.exec` (The JaCoCo execution data)
        - `target/site/jacoco/index.html` (The full HTML report)
2. **[JavaDoc](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html)**
    - To generate the JavaDoc JAR (in `target/`): `$ mvn clean package`
    - To generate the full HTML site (in `target/site/apidocs/index.html`): `$ mvn javadoc:aggregate`
3. **[Swagger](https://swagger.io/)**
    - To see a fully interactive documentation page showing the status endpoint (Previously a basic controller and metadata were added): `mvn clean spring-boot:run`
    - Open the web browser and navigate to: `http://localhost:8080/swagger-ui.html`
  